### PR TITLE
Corrige conflito de portas entre bot e servidor web

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "node index.js",
     "dev": "node --watch index.js",
     "web": "node web/server.js",
-    "bot": "node index.js",
+    "bot": "EXTERNAL_WEB_SERVER=true node index.js",
     "panel": "node web/server.js",
     "both": "concurrently \"npm run bot\" \"npm run web\""
   },


### PR DESCRIPTION
- Adiciona variável EXTERNAL_WEB_SERVER para controlar carregamento do servidor web
- Modifica script 'bot' para definir EXTERNAL_WEB_SERVER=true no npm run both
- Melhora tratamento de webServer null nas funções loadWebConfig e updateWebStatus
- Permite execução simultânea sem conflito de porta 3001
- Bot agora funciona independentemente do servidor web